### PR TITLE
ssh fix ubuntu 22.04.5

### DIFF
--- a/src/customizeImage.sh
+++ b/src/customizeImage.sh
@@ -159,6 +159,11 @@ cd /home/ubuntu/connectedhomeip && find . -maxdepth 1 ! -name out -exec rm -fr {
 sh -c 'echo 3 > /proc/sys/vm/drop_caches'
 cd /home/ubuntu && rm -rf ./.cache/* ./.cipd-cache-dir/* ./zap ./ot-br-posix
 
+#creating a file which comes alphabetically before 50-cloud-init.conf such that it ovewrites the  config
+sudo tee /etc/ssh/sshd_config.d/40-user-config.conf > /dev/null <<EOL
+PasswordAuthentication yes
+EOL
+
 chmod a-x ./scripts/matterTool.sh
 mv /etc/apt/apt.conf.d/70debconf.bak /etc/apt/apt.conf.d/70debconf
 rm -f /etc/resolv.conf

--- a/src/scripts/Versions.txt
+++ b/src/scripts/Versions.txt
@@ -1,6 +1,6 @@
 Versions
 * Silicon Labs Matter Extension: v2.4.0-1.4
-* Matter / Chip-Tool: eb2936c73b 
+* Matter / Chip-Tool: fd2d0000ee 
 * OpenThread
   * ot-efr32: 2980044
   * openthread: 1fceb225b

--- a/src/scripts/releases.json
+++ b/src/scripts/releases.json
@@ -1,6 +1,6 @@
 { "release":"v2.4.0-1.4-ext",
   "commits": {
-		"chipTool": "eb2936c73b",
+		"chipTool": "fd2d0000ee",
 		"otefr32": "2980044",
 		"openthread": "1fceb225b",
 		"otbrposix": "e56c02006",


### PR DESCRIPTION
The new ubuntu image comes with issues for ssh fix with new config file which allows passwordAuthentication. 

create  file for ssh configuration fix
using rigth chip tool version