### PR TITLE
Fix invalid command due to space in front of it

### DIFF
--- a/src/scripts/templates/configurations_eth0.sh
+++ b/src/scripts/templates/configurations_eth0.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
- sudo iptables -A FORWARD -i eth0 -o wpan0 -j ACCEPT
- sudo iptables -A FORWARD -i wpan0 -o eth0 -j ACCEPT
+sudo iptables -A FORWARD -i eth0 -o wpan0 -j ACCEPT
+sudo iptables -A FORWARD -i wpan0 -o eth0 -j ACCEPT

--- a/src/scripts/templates/configurations_wlan0.sh
+++ b/src/scripts/templates/configurations_wlan0.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
- sudo iptables -A FORWARD -i wlan0 -o wpan0 -j ACCEPT
- sudo iptables -A FORWARD -i wpan0 -o wlan0 -j ACCEPT
+sudo iptables -A FORWARD -i wlan0 -o wpan0 -j ACCEPT
+sudo iptables -A FORWARD -i wpan0 -o wlan0 -j ACCEPT


### PR DESCRIPTION
Remove space in front of the command in the templates.

It causes the command to be invalid and therefore it does not apply the iptables config on bootup