### PR TITLE
chiptool sha update for CSA 1.4.1 

### DIFF
--- a/src/scripts/Versions.txt
+++ b/src/scripts/Versions.txt
@@ -1,6 +1,6 @@
 Versions
 * Silicon Labs Matter Extension: v2.6.0-1.4
-* Matter / Chip-Tool: fd2d0000ee 
+* Matter / Chip-Tool: ba6168ccd9 
 * OpenThread
   * ot-efr32: 0b2bcd9
   * openthread: fb0446f53

--- a/src/scripts/releases.json
+++ b/src/scripts/releases.json
@@ -1,6 +1,6 @@
 { "release":"v2.6.0-1.4-ext",
   "commits": {
-		"chipTool": "fd2d0000ee",
+		"chipTool": "ba6168ccd9",
 		"otefr32": "0b2bcd9",
 		"openthread": "fb0446f53",
 		"otbrposix": "622f5ecf",


### PR DESCRIPTION
Referenced from the matter_sdk PR https://github.com/SiliconLabsSoftware/matter_sdk/pull/449 to merge CSA update (1.4.1)  into release_2.6-1.4 